### PR TITLE
Introduce failure rate as part of monitoring config

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,7 @@ dependencies {
     implementation group: 'ch.qos.logback', name: 'logback-classic', version: '1.2.3'
     implementation group: 'org.apache.commons', name: 'commons-lang3', version: '3.12.0'
     implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-xml', version: '2.12.4'
+    implementation group: 'com.fasterxml.jackson.dataformat', name: 'jackson-dataformat-yaml', version: '2.12.3'
     testImplementation group: 'javax.ws.rs', name: 'javax.ws.rs-api', version: '2.0'
 }
 

--- a/src/main/java/dev/manpreet/kaostest/Runner.java
+++ b/src/main/java/dev/manpreet/kaostest/Runner.java
@@ -1,5 +1,6 @@
 package dev.manpreet.kaostest;
 
+import dev.manpreet.kaostest.dto.MonitoringConfig;
 import dev.manpreet.kaostest.dto.internal.RunnerStore;
 import dev.manpreet.kaostest.dto.internal.TestStore;
 import dev.manpreet.kaostest.dto.xml.Suite;
@@ -8,9 +9,11 @@ import dev.manpreet.kaostest.providers.ThreadCountProvider;
 import dev.manpreet.kaostest.providers.duration.FixedDurationProvider;
 import dev.manpreet.kaostest.providers.threadcount.FixedThreadCountProvider;
 import dev.manpreet.kaostest.runner.TestRunnersManager;
+import dev.manpreet.kaostest.util.CommonUtils;
 import dev.manpreet.kaostest.util.SuiteXMLUtils;
 import lombok.extern.slf4j.Slf4j;
 
+import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 
 /**
@@ -18,6 +21,20 @@ import java.util.concurrent.TimeUnit;
  */
 @Slf4j
 public class Runner {
+
+    private MonitoringConfig monitoringConfig;
+
+    public Runner() {
+        monitoringConfig = CommonUtils.getMonitoringConfigFromEnvironment();
+    }
+
+    public Runner(String monitoringConfigYAML) {
+        monitoringConfig = CommonUtils.getMonitoringConfigFromYAMLFile(monitoringConfigYAML);
+    }
+
+    public Runner(MonitoringConfig monitoringConfig) {
+        this.monitoringConfig = monitoringConfig;
+    }
 
     /**
      * Run the tests in the defined suite XML for 5 minutes in 10 threads
@@ -37,7 +54,7 @@ public class Runner {
      * @return RunnerStore - Holds statistics about the complete execution
      */
     public RunnerStore runTests(String suiteXmlPath, ThreadCountProvider threadCountProvider, DurationProvider durationProvider) {
-
+        monitoringConfig.sanitizeConfig(threadCountProvider);
         Suite suite = SuiteXMLUtils.deserializeSuiteXML(suiteXmlPath);
         if (!SuiteXMLUtils.isSuiteValid(suite)) {
             throw new KaosException("Validation of suite XML failed. Please check logs");

--- a/src/main/java/dev/manpreet/kaostest/dto/MonitoringConfig.java
+++ b/src/main/java/dev/manpreet/kaostest/dto/MonitoringConfig.java
@@ -1,0 +1,22 @@
+package dev.manpreet.kaostest.dto;
+
+import dev.manpreet.kaostest.providers.PollingProvider;
+import dev.manpreet.kaostest.providers.ThreadCountProvider;
+import lombok.Data;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Data
+public class MonitoringConfig {
+
+    private Integer failureRatePollSeconds;
+
+    public void sanitizeConfig(ThreadCountProvider threadCountProvider) {
+        if (failureRatePollSeconds == null || failureRatePollSeconds < 10) {
+            log.warn("Invalid value set for failureRatePollSeconds in monitoringConfig");
+            failureRatePollSeconds = threadCountProvider instanceof PollingProvider ?
+                    ((PollingProvider) threadCountProvider).getPollSeconds() : 60;
+            log.warn("failureRatePollSeconds set to default value of " + failureRatePollSeconds);
+        }
+    }
+}

--- a/src/main/java/dev/manpreet/kaostest/util/CommonUtils.java
+++ b/src/main/java/dev/manpreet/kaostest/util/CommonUtils.java
@@ -1,0 +1,37 @@
+package dev.manpreet.kaostest.util;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import dev.manpreet.kaostest.dto.MonitoringConfig;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.commons.lang3.StringUtils;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Optional;
+
+@Slf4j
+public class CommonUtils {
+
+    public static MonitoringConfig getMonitoringConfigFromEnvironment() {
+        if (StringUtils.defaultString(System.getenv(Constants.CONFIG_FILE_ENV)).isBlank()) {
+            return new MonitoringConfig();
+        }
+        return getMonitoringConfigFromYAMLFile(System.getenv(Constants.CONFIG_FILE_ENV));
+    }
+
+    public static MonitoringConfig getMonitoringConfigFromYAMLFile(String yamlFile) {
+        File configFile = new File(yamlFile);
+        if (!configFile.exists() || !configFile.canRead()) {
+            log.warn("Unable to read config file at " + yamlFile);
+            return new MonitoringConfig();
+        }
+        ObjectMapper yamlMapper = new ObjectMapper(new YAMLFactory());
+        try {
+            return yamlMapper.readValue(configFile, MonitoringConfig.class);
+        } catch (IOException ioException) {
+            log.error("Exception occurred while trying to read YAML file at " + yamlFile);
+        }
+        return new MonitoringConfig();
+    }
+}

--- a/src/main/java/dev/manpreet/kaostest/util/Constants.java
+++ b/src/main/java/dev/manpreet/kaostest/util/Constants.java
@@ -1,0 +1,6 @@
+package dev.manpreet.kaostest.util;
+
+public class Constants {
+
+    public static final String CONFIG_FILE_ENV = "KAOS_CONFIG_YAML";
+}

--- a/src/main/resources/monitoringConfig.yaml
+++ b/src/main/resources/monitoringConfig.yaml
@@ -1,0 +1,2 @@
+monitoringConfig:
+  failureRatePollSeconds: 30


### PR DESCRIPTION
Will be adding failure rate monitoring feature which, at the end of the run, will add failure rate of the tests to the stats at the end of the run. This is part of a larger continuous effort to improve the monitoring for the suite execution.